### PR TITLE
Fix incorrect link to Tyagi et al. paper in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Segment Anything Model (SAM) uses vision transformer-based image encoder to extr
 |202311|X. Wei et al.|I-MedSAM: Implicit Medical Image Segmentation with Segment Anything [(paper)](https://arxiv.org/pdf/2311.17081.pdf)|None|
 |202311|Z. Shui et al.|Unleashing the Power of Prompt-driven Nucleus Instance Segmentation [(paper)](https://arxiv.org/pdf/2311.15939.pdf)|[Code](https://github.com/windygoo/PromptNucSeg)|
 |202311|M. Li and G. Yang et al.|Where to Begin? From Random to Foundation Model Instructed Initialization in Federated Learning for Medical Image Segmentation [(paper)](https://arxiv.org/pdf/2311.15463.pdf)|None|
-|202311|AK. Tyagi et al.|Guided Prompting in SAM for Weakly Supervised Cell Segmentation in Histopathological Images [(paper)](https://arxiv.org/pdf/2311.13385.pdf)|[Code](https://github.com/dair-iitd/Guided-Prompting-SAM)|
+|202311|AK. Tyagi et al.|Guided Prompting in SAM for Weakly Supervised Cell Segmentation in Histopathological Images [(paper)](https://arxiv.org/pdf/2311.17960.pdf)|[Code](https://github.com/dair-iitd/Guided-Prompting-SAM)|
 |202311|Y. Du et al.|SegVol: Universal and Interactive Volumetric Medical Image Segmentation [(paper)](https://arxiv.org/pdf/2311.13385.pdf)|[Code](https://github.com/BAAI-DCAI/SegVol)|
 |202311|DM. Nguyen et al.|On the Out of Distribution Robustness of Foundation Models in Medical Image Segmentation [(paper)](https://arxiv.org/pdf/2311.11096.pdf)|None|
 |202311|U. Israel et al.|A Foundation Model for Cell Segmentation [(paper)](https://www.biorxiv.org/content/10.1101/2023.11.17.567630v2.abstract)|[Code](https://label-dev.deepcell.org)|


### PR DESCRIPTION
### Update Hyperlink in README

**Change Description**
This pull request corrects a hyperlink in the README file.

**Details**
- The original link pointed to "SegVol: Universal and Interactive Volumetric Medical Image Segmentation" by Du et al.
- It's now updated to point to "Guided Prompting in SAM for Weakly Supervised Cell Segmentation in Histopathological Images" by Tyagi et al.

**Reason for Change**
This update ensures that readers are directed to the correct research paper, improving the accuracy and usefulness of the documentation.